### PR TITLE
Implement custom assertion templating for mcp server

### DIFF
--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -429,6 +429,50 @@ class MCPHTTPPlaywrightServer {
                     type: "object",
                     properties: {}
                   }
+                },
+                {
+                  name: "assert_template",
+                  description: "Run custom assertions defined in a template",
+                  inputSchema: {
+                    type: "object",
+                    properties: {
+                      navigate: {
+                        type: "object",
+                        properties: {
+                          url: { type: "string", description: "URL to navigate to before assertions" },
+                          waitUntil: { type: "string", enum: ["load", "domcontentloaded", "networkidle"] },
+                          timeout: { type: "number" }
+                        }
+                      },
+                      assertions: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            type: { 
+                              type: "string",
+                              enum: [
+                                "page_title","page_url","visible","attached","hidden","detached","text","attribute","count","css","value","checked","enabled","in_viewport"
+                              ]
+                            },
+                            selector: { type: "string" },
+                            attribute: { type: "string" },
+                            name: { type: "string" },
+                            expected: { },
+                            contains: { type: "string" },
+                            regex: { type: "string" },
+                            flags: { type: "string" },
+                            count: { type: "number" },
+                            comparator: { type: "string", enum: ["equals","contains","matches","gt","gte","lt","lte"] },
+                            timeout: { type: "number" },
+                            ratio: { type: "number" },
+                          },
+                          required: ["type"]
+                        }
+                      }
+                    },
+                    required: ["assertions"]
+                  }
                 }
               ]
             };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
+    "types": ["node"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Add `assert_template` MCP tool to enable templated custom assertions.

---
<a href="https://cursor.com/background-agent?bcId=bc-d19a8591-855b-4372-b848-81e30280c59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d19a8591-855b-4372-b848-81e30280c59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

